### PR TITLE
Fix an issue where chef_oauth2_url wasn't being set from chef_server_url

### DIFF
--- a/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -368,7 +368,7 @@ default['supermarket']['learn_chef_url'] = "https://learn.#{node['supermarket'][
 # false.
 default['supermarket']['chef_oauth2_app_id'] = nil
 default['supermarket']['chef_oauth2_secret'] = nil
-default['supermarket']['chef_oauth2_url'] = node['supermarket']['chef_server_url']
+default['supermarket']['chef_oauth2_url'] = nil
 default['supermarket']['chef_oauth2_verify_ssl'] = true
 
 # ### CLA Settings

--- a/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -39,6 +39,11 @@ Supermarket::Config.load_or_create_secrets!(
 node.consume_attributes('nginx' => node['supermarket']['nginx'],
                         'runit' => node['supermarket']['runit'])
 
+# set chef_oauth2_url from chef_server_url after this value has been loaded from config
+if node['supermarket']['chef_server_url'] && node['supermarket']['chef_oauth2_url'].nil?
+  node.set['supermarket']['chef_oauth2_url'] = node['supermarket']['chef_server_url']
+end
+
 user node['supermarket']['user']
 
 group node['supermarket']['group'] do


### PR DESCRIPTION
...causing users to be redirected to id.opscode.com instead of chef_server_url
