### PR TITLE
add canonical redirect exception for Ruby user agent

### DIFF
--- a/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
+++ b/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
@@ -64,6 +64,12 @@ server {
     set $redirect_to_canonical 0;
   }
 
+  # This stops redirects for knife cookbook site share, which uses net/http,
+  # and thus 'Ruby' as the user agent.
+  if ($http_user_agent ~ 'Ruby') {
+    set $redirect_to_canonical 0;
+  }
+
   if ($redirect_to_canonical = H) {
     return 301 http<%= node['supermarket']['nginx']['force_ssl'] ? 's' : '' %>://<%= node['supermarket']['fqdn'] %>$request_uri;
   }


### PR DESCRIPTION
This does the same thing that our internal cookbook does to avoid failing on redirects on `knife cookbook site share`.
