### PR TITLE
Simplify Unicorn config

### DIFF
--- a/config/templates/supermarket-ctl/supermarket-ctl.erb
+++ b/config/templates/supermarket-ctl/supermarket-ctl.erb
@@ -27,4 +27,8 @@ do
   unset $ruby_env_var
 done
 
+# This bumps the default svwait timeout from 7 seconds to 30 seconds
+# As documented at http://smarden.org/runit/sv.8.html
+export SVWAIT=30
+
 <%= embedded_bin %>/omnibus-ctl supermarket <%= embedded_service %>/omnibus-ctl $@

--- a/cookbooks/omnibus-supermarket/recipes/rails.rb
+++ b/cookbooks/omnibus-supermarket/recipes/rails.rb
@@ -36,6 +36,7 @@ template "#{node['supermarket']['var_directory']}/etc/unicorn.rb" do
   owner node['supermarket']['user']
   group node['supermarket']['group']
   mode '0600'
+  variables(node['supermarket']['unicorn'].to_hash)
   notifies :restart, 'runit_service[rails]'
 end
 

--- a/cookbooks/omnibus-supermarket/recipes/rails.rb
+++ b/cookbooks/omnibus-supermarket/recipes/rails.rb
@@ -30,56 +30,13 @@ include_recipe 'omnibus-supermarket::nginx'
   end
 end
 
-# Before and after fork blocks for Unicorn.
-#
-# We'll probably want to factor these out into something else when we do the
-# same setup for Fieri.
-before_fork = node['supermarket']['unicorn']['before_fork'] || <<EOF
-  # When sent a USR2, Unicorn will suffix its pidfile with .oldbin and
-  # immediately start loading up a new version of itself (loaded with a new
-  # version of our app). This new Unicorn, before it forks workers, will check
-  # to see if an .oldbin pidfile exists. If so, this means we've just booted up
-  # a new Unicorn and need to tell the old one that it can now die. To do so
-  # we send it a QUIT.
-  #
-  # Using this method we get 0 downtime deploys.
-  old_pid = "#{node['supermarket']['unicorn']['pid']}.oldbin"
-
-  if File.exists?(old_pid) && server.pid != old_pid
-    begin
-      Process.kill('QUIT', File.read(old_pid).to_i)
-
-      defined?(ActiveRecord::Base) &&
-        ActiveRecord::Base.connection.disconnect!
-     rescue Errno::ENOENT, Errno::ESRCH
-      # someone else did our job for us
-    end
-  end
-EOF
-
-after_fork = node['supermarket']['unicorn']['after_fork'] || <<EOF
-  Signal.trap 'TERM' do
-    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
-  end
-
-  defined?(ActiveRecord::Base) &&
-    ActiveRecord::Base.establish_connection
-EOF
-
 template "#{node['supermarket']['var_directory']}/etc/unicorn.rb" do
   source 'unicorn.rb.erb'
   cookbook 'unicorn'
   owner node['supermarket']['user']
   group node['supermarket']['group']
   mode '0600'
-  variables node['supermarket']['unicorn'].merge(
-    :before_fork => before_fork, :after_fork => after_fork
-  )
   notifies :restart, 'runit_service[rails]'
-end
-
-link "#{node['supermarket']['app_directory']}/config/unicorn.rb" do
-  to "#{node['supermarket']['var_directory']}/etc/unicorn.rb"
 end
 
 template "#{node['supermarket']['nginx']['directory']}/sites-enabled/rails" do

--- a/cookbooks/omnibus-supermarket/templates/default/sv-rails-run.erb
+++ b/cookbooks/omnibus-supermarket/templates/default/sv-rails-run.erb
@@ -1,111 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 exec 2>&1
 
-#
-# Since unicorn creates a new pid on restart/reload, it needs a little extra love to
-# manage with runit. Instead of managing unicorn directly, we simply trap signal calls
-# to the service and redirect them to unicorn directly.
-#
+export PATH=<%= node['supermarket']['install_directory'] %>/embedded/bin:$PATH
+export LD_LIBRARY_PATH=<%= node['supermarket']['install_directory'] %>/embedded/lib
+cd <%= node['supermarket']['install_directory'] %>/embedded/service/supermarket
 
-RUNIT_PID=$$
-CUR_PID_FILE=<%= node['supermarket']['unicorn']['pid'] %>
-OLD_PID_FILE=$CUR_PID_FILE.oldbin
-
-echo "Runit service restarted (PID: $RUNIT_PID)"
-
-function is_unicorn_alive {
-    set +e
-    if [ -n $1 ] && kill -0 $1 >/dev/null 2>&1; then
-        echo "yes"
-    fi
-    set -e
-}
-
-if [ -e $OLD_PID_FILE ]; then
-    OLD_PID=$(cat $OLD_PID_FILE)
-    echo "Old master detected (PID: $OLD_PID), waiting for it to exit"
-    while [ -n "$(is_unicorn_alive $OLD_PID)" ]; do
-        echo -n '.'
-        sleep 2
-    done
-fi
-
-if [ -e $CUR_PID_FILE ]; then
-    CUR_PID=$(cat $CUR_PID_FILE)
-    if [ -n "$(is_unicorn_alive $CUR_PID)" ]; then
-        echo "Detected running Unicorn instance (PID: $CUR_PID)"
-        RUNNING=true
-    fi
-fi
-
-function start {
-  unset ACTION
-  if [ $RUNNING ]; then
-    restart
-  else
-    echo 'Starting new Unicorn instance'
-    cd <%= node['supermarket']['app_directory'] %>
-    exec <%= node['runit']['chpst_bin'] %> \
-           -u <%= node['supermarket']['unicorn']['forked_user'] %> \
-           -P \
-         env \
-          PATH=<%= node['supermarket']['install_directory'] %>/embedded/bin:$PATH \
-         bundle exec unicorn \
-            --config-file config/unicorn.rb \
-            --daemonize \
-            --env production
-    sleep 3
-    CUR_PID=$(cat $CUR_PID_FILE)
-  fi
-}
-
-function stop {
-  unset ACTION
-  echo 'Initializing graceful shutdown'
-  kill -QUIT $CUR_PID
-
-  while [ -n "$(is_unicorn_alive $CUR_PID)" ]; do
-    echo -n '.'
-    sleep 2
-  done
-
-  echo 'Unicorn stopped, exiting Runit process'
-  kill -9 $RUNIT_PID
-}
-
-function restart {
-  unset ACTION
-  echo "Restart request captured, swapping old master (PID: $CUR_PID) for new master with USR2"
-  kill -USR2 $CUR_PID
-
-  sleep 2
-  echo 'Restarting Runit service to capture new master PID'
-  exit
-}
-
-function alarm {
-  unset ACTION
-  echo 'Unicorn process interrupted'
-}
-
-trap 'ACTION=stop' STOP TERM KILL
-trap 'ACTION=restart' QUIT USR2 INT
-trap 'ACTION=alarm' ALRM
-
-[ $RUNNING ] || ACTION=start
-
-if [ $ACTION ]; then
-  echo "Performing \"$ACTION\" action and going into sleep mode until new signal captured"
-elif [ $RUNNING ]; then
-  echo "Going into sleep mode until new signal captured"
-fi
-
-if [ $ACTION ] || [ $RUNNING ]; then
-  while true; do
-    [ "$ACTION" == 'start' ] && start
-    [ "$ACTION" == 'stop' ] && stop
-    [ "$ACTION" == 'restart' ] && restart
-    [ "$ACTION" == 'alarm' ] && alarm
-    sleep 2
-  done
-fi
+exec <%= node['runit']['chpst_bin'] %> \
+  -P \
+  -U <%= node['supermarket']['unicorn']['forked_user'] %> \
+  -u <%= node['supermarket']['unicorn']['forked_user'] %> \
+    bundle exec unicorn -E production \
+      -c <%= node['supermarket']['var_directory'] %>/etc/unicorn.rb
+      <%= node['supermarket']['install_directory'] %>/embedded/service/supermarket/config.ru


### PR DESCRIPTION
This PR simplifies the RUnit config for the Rails app. Instead of daemonizing Unicorn we just let RUnit fully control the process. This approach matches how we start and manage our other Rails applications:

* oc-id - Ships in Chef Server 12.
* chef-manage - Ships in opscode-manage.

Test CI run here: http://wilson.ci.chef.co/job/supermarket-trigger-ad_hoc/8/downstreambuildview/

/cc @kirtfitzpatrick @chef/ociv @nellshamrell @smith 