### PR TITLE
Fix two PostgreSQL configuration typos

### DIFF
--- a/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -303,7 +303,7 @@ default['supermarket']['database']['name'] = 'supermarket'
 default['supermarket']['database']['host'] = node['supermarket']['postgresql']['listen_address']
 default['supermarket']['database']['port'] = node['supermarket']['postgresql']['port']
 default['supermarket']['database']['pool'] = node['supermarket']['sidekiq']['concurrency']
-default['supermarket']['database']['extensions'] = { 'pgpsql' => true, 'pg_trgm' => 'true' }
+default['supermarket']['database']['extensions'] = { 'plpgsql' => true, 'pg_trgm' => 'true' }
 
 # ## App-specific top-level attributes
 #

--- a/cookbooks/omnibus-supermarket/recipes/database.rb
+++ b/cookbooks/omnibus-supermarket/recipes/database.rb
@@ -44,7 +44,7 @@ node['supermarket']['database']['extensions'].each do |ext, enable|
   execute "create postgresql #{ext} extension" do
     user node['supermarket']['database']['user']
     command "echo 'CREATE EXTENSION IF NOT EXISTS #{ext}' | psql"
-    not_if "echo '\dx' | psql #{node['supermarket']['database']['name']} | grep #{ext}"
+    not_if "echo '\\dx' | psql #{node['supermarket']['database']['name']} | grep #{ext}"
   end
 end
 


### PR DESCRIPTION
1.  The `not_if` statement when checking for extensions doesn't work, `\dx` gets turned into `dx` because the backslash is treated as an escape character, generating the following error:
  ```
  2015-05-08_16:42:39.45485 ERROR:  syntax error at or near "dx" at character 1
  2015-05-08_16:42:39.45504 STATEMENT:  dx
  ```

2.  One of the PostgreSQL extensions is typoed as `pgpsql`, fix that.