### PR TITLE
adding in gravatar features documentation

### DIFF
--- a/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -401,7 +401,7 @@ default['supermarket']['seed_cla_data'] = nil
 # * gravatar: Enable Gravatar integration, used for user avatars
 # * join_ccla: Enable joining of Corporate CLAs
 # * tools: Enable the tools section
-default['supermarket']['features'] = 'tools'
+default['supermarket']['features'] = 'tools, gravatar'
 
 # ### robots.txt Settings
 #

--- a/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -398,7 +398,7 @@ default['supermarket']['seed_cla_data'] = nil
 # * fieri: Use the fieri service to report on cookbook quality (requires
 #   fieri_url and fieri_key to be set.)
 # * github: Enable GitHub integration, used with CLA signing
-# * gravatar: Enable Gravatr integration, used for user avatars
+# * gravatar: Enable Gravatar integration, used for user avatars
 # * join_ccla: Enable joining of Corporate CLAs
 # * tools: Enable the tools section
 default['supermarket']['features'] = 'tools'

--- a/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -398,6 +398,7 @@ default['supermarket']['seed_cla_data'] = nil
 # * fieri: Use the fieri service to report on cookbook quality (requires
 #   fieri_url and fieri_key to be set.)
 # * github: Enable GitHub integration, used with CLA signing
+# * gravatar: Enable Gravatr integration, used for user avatars
 # * join_ccla: Enable joining of Corporate CLAs
 # * tools: Enable the tools section
 default['supermarket']['features'] = 'tools'


### PR DESCRIPTION
This is related to this Supermarket pull request: https://github.com/chef/supermarket/pull/1038

Some customers requested the ability to disable gravatars on their private Supermarket instances.  With some advice from @smith, I decided to make gravatar a feature that users can enable on demand.  This adds in documentation around this feature.