### PR TITLE
update enterprise cookbook to 0.7.0.

### DIFF
--- a/cookbooks/omnibus-supermarket/Berksfile
+++ b/cookbooks/omnibus-supermarket/Berksfile
@@ -4,4 +4,4 @@ metadata
 
 cookbook 'enterprise',
          git: 'https://github.com/opscode-cookbooks/enterprise-chef-common.git',
-         tag: '0.6.0'
+         tag: '0.7.0'

--- a/cookbooks/omnibus-supermarket/Berksfile.lock
+++ b/cookbooks/omnibus-supermarket/Berksfile.lock
@@ -1,8 +1,8 @@
 DEPENDENCIES
   enterprise
     git: https://github.com/opscode-cookbooks/enterprise-chef-common.git
-    revision: 76da59088177a774513b3eb30fff54c0c294fe33
-    tag: 0.6.0
+    revision: c81c8aaa9215cea47a67866221b7a81ae4da2085
+    tag: 0.7.0
   omnibus-supermarket
     path: .
     metadata: true
@@ -16,7 +16,7 @@ GRAPH
   build-essential (2.0.6)
   chef-sugar (2.4.1)
   chef_handler (1.1.6)
-  enterprise (0.6.0)
+  enterprise (0.7.0)
     runit (> 1.0.0)
   homebrew (1.9.2)
   nginx (2.7.4)


### PR DESCRIPTION
There's a bug related to ChefSpec in the 0.6.0 release that was causing
the builds to fail.

This fixes that, but does not fix the problem where passing in a
password option does not work properly.