### PR TITLE
removing code made in Pull #23

### DIFF
--- a/cookbooks/omnibus-supermarket/Berksfile
+++ b/cookbooks/omnibus-supermarket/Berksfile
@@ -4,4 +4,4 @@ metadata
 
 cookbook 'enterprise',
          git: 'https://github.com/opscode-cookbooks/enterprise-chef-common.git',
-         tag: '0.6.0'
+         tag: '0.5.2'

--- a/cookbooks/omnibus-supermarket/Berksfile.lock
+++ b/cookbooks/omnibus-supermarket/Berksfile.lock
@@ -1,8 +1,8 @@
 DEPENDENCIES
   enterprise
     git: https://github.com/opscode-cookbooks/enterprise-chef-common.git
-    revision: 76da59088177a774513b3eb30fff54c0c294fe33
-    tag: 0.6.0
+    revision: 454d6a3e7d349a25a3c6732761e8e095811219c7
+    tag: 0.5.2
   omnibus-supermarket
     path: .
     metadata: true
@@ -16,7 +16,7 @@ GRAPH
   build-essential (2.0.6)
   chef-sugar (2.4.1)
   chef_handler (1.1.6)
-  enterprise (0.6.0)
+  enterprise (0.4.4)
     runit (> 1.0.0)
   homebrew (1.9.2)
   nginx (2.7.4)

--- a/cookbooks/omnibus-supermarket/recipes/database.rb
+++ b/cookbooks/omnibus-supermarket/recipes/database.rb
@@ -29,9 +29,10 @@ ENV['PGPORT'] = node['supermarket']['database']['port'].to_s
 enterprise_pg_user node['supermarket']['database']['user'] do
   superuser true
   password node['supermarket']['database']['password'] || ''
-  admin_username node['supermarket']['postgresql']['username'] unless node['supermarket']['postgresql']['enable']
-  admin_password node['supermarket']['postgresql']['password'] unless node['supermarket']['postgresql']['enable']
-  host node['supermarket']['database']['host'] unless node['supermarket']['postgresql']['enable']
+#  Commenting these out until a bug is fixed with the database provider in https://github.com/opscode-cookbooks/enterprise-chef-common
+#  admin_username node['supermarket']['postgresql']['username'] unless node['supermarket']['postgresql']['enable']
+#  admin_password node['supermarket']['postgresql']['password'] unless node['supermarket']['postgresql']['enable']
+#  host node['supermarket']['database']['host'] unless node['supermarket']['postgresql']['enable']
   # If the database user is the same as the main postgres user, don't create it.
   not_if do
     node['supermarket']['database']['user'] ==
@@ -41,9 +42,10 @@ end
 
 enterprise_pg_database node['supermarket']['database']['name'] do
   owner node['supermarket']['database']['user']
-  username node['supermarket']['postgresql']['username'] unless node['supermarket']['postgresql']['enable']
-  password node['supermarket']['postgresql']['password'] unless node['supermarket']['postgresql']['enable']
-  host node['supermarket']['database']['host'] unless node['supermarket']['postgresql']['enable']
+#  Commenting these out until a bug is fixed with the database provider in https://github.com/opscode-cookbooks/enterprise-chef-common
+#  username node['supermarket']['postgresql']['username'] unless node['supermarket']['postgresql']['enable']
+#  password node['supermarket']['postgresql']['password'] unless node['supermarket']['postgresql']['enable']
+#  host node['supermarket']['database']['host'] unless node['supermarket']['postgresql']['enable']
 end
 
 node['supermarket']['database']['extensions'].each do |ext, enable|


### PR DESCRIPTION
Earlier today #23 was merged.

Unfortunately, due to an upstream issue with https://github.com/opscode-cookbooks/enterprise-chef-common, this broke the build.  

This error we received on the build was:

```
[0mNameError[0m
---------[0m
No resource, method, or local variable named `connection_string' for `Chef::Provider::EnterprisePgDatabase ""'[0m

[0mCookbook Trace:[0m
---------------[0m
/opt/supermarket/embedded/cookbooks/cache/cookbooks/enterprise/providers/pg_database.rb:34:in `createdb_command'
[0m/opt/supermarket/embedded/cookbooks/cache/cookbooks/enterprise/providers/pg_database.rb:22:in `block (2 levels) in class_from_file'
[0m/opt/supermarket/embedded/cookbooks/cache/cookbooks/enterprise/providers/pg_database.rb:21:in `block in class_from_file'[0m
```

This error needs to be fixed in enterprise-chef-common before our build can pass while using the pg_database resources.

Reverting the code (wasn't able to revert the merge) for now until this fix is complete.