### PR TITLE
Change Ruby to v2.1.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 9eaca4fa6928dbc720842c17a1e7672812afa621
+  revision: 2c5403e1cc33645cfc1c44decc2416bbda594f2c
   specs:
     omnibus-software (4.0.0)
 

--- a/config/projects/supermarket.rb
+++ b/config/projects/supermarket.rb
@@ -29,7 +29,7 @@ end
 build_iteration 1
 
 override :postgresql, version: '9.3.6'
-override :ruby, version: "2.2.3"
+override :ruby, version: "2.1.8"
 override :rubygems, version: "2.4.8"
 override :git, version: "2.2.1"
 override :'chef-gem', version: '12.3.0'


### PR DESCRIPTION
We needed to revert back to Ruby 2.1 because of trouble[1] with rails
console, Ruby 2.2, and probably an unidentified dependency that's choking.

[1] Fixes chef/supermarket#1183