### PR TITLE
Fix broken specs and deprecations

### DIFF
--- a/cookbooks/omnibus-supermarket/spec/recipes/app_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/app_spec.rb
@@ -1,6 +1,6 @@
 describe 'omnibus-supermarket::app' do
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['memory']['total'] = '16000MB'
     end.converge(described_recipe)
   end

--- a/cookbooks/omnibus-supermarket/spec/recipes/config_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/config_spec.rb
@@ -1,6 +1,6 @@
 describe 'omnibus-supermarket::config' do
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['memory']['total'] = '16000MB'
     end.converge(described_recipe)
   end

--- a/cookbooks/omnibus-supermarket/spec/recipes/database_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/database_spec.rb
@@ -5,7 +5,7 @@ describe 'omnibus-supermarket::database' do
   end
 
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['memory']['total'] = '16000MB'
     end.converge(described_recipe)
   end

--- a/cookbooks/omnibus-supermarket/spec/recipes/database_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/database_spec.rb
@@ -1,4 +1,9 @@
 describe 'omnibus-supermarket::database' do
+  before do
+    stub_command("echo '\\dx' | psql supermarket | grep plpgsql").and_return('')
+    stub_command("echo '\\dx' | psql supermarket | grep pg_trgm").and_return('')
+  end
+
   let(:chef_run) do
     ChefSpec::Runner.new do |node|
       node.automatic['memory']['total'] = '16000MB'

--- a/cookbooks/omnibus-supermarket/spec/recipes/nginx_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/nginx_spec.rb
@@ -1,6 +1,6 @@
 describe 'omnibus-supermarket::nginx' do
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['memory']['total'] = '16000MB'
     end.converge(described_recipe)
   end

--- a/cookbooks/omnibus-supermarket/spec/recipes/postgresql_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/postgresql_spec.rb
@@ -1,6 +1,6 @@
 describe 'omnibus-supermarket::postgresql' do
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['memory']['total'] = '16000MB'
     end.converge(described_recipe)
   end

--- a/cookbooks/omnibus-supermarket/spec/recipes/redis_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/redis_spec.rb
@@ -1,6 +1,6 @@
 describe 'omnibus-supermarket::redis' do
   let(:chef_run) do
-    ChefSpec::Runner.new do |node|
+    ChefSpec::SoloRunner.new do |node|
       node.automatic['memory']['total'] = '16000MB'
     end.converge(described_recipe)
   end


### PR DESCRIPTION
Fix for https://github.com/chef/supermarket/issues/1056

Also fixes these warnings we were seeing throughout the run:
```
6:00:39-nshamrell~/Projects/omnibus-supermarket/cookbooks/omnibus-supermarket (fix-broken-specs-dec)$ bundle exec rspec
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/app_spec.rb:3
:in `block (2 levels) in <top (required)>')
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/app_spec.rb:3
:in `block (2 levels) in <top (required)>')
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/app_spec.rb:3
:in `block (2 levels) in <top (required)>')
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/config_spec.r
b:3:in `block (2 levels) in <top (required)>')
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/config_spec.r
b:3:in `block (2 levels) in <top (required)>')
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/config_spec.r
b:3:in `block (2 levels) in <top (required)>')
.[DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/recipes/config_spec.r
b:3:in `block (2 levels) in <top (required)>')
```