### PR TITLE
Pin berkshelf to a version prior to requiring net-ssh 3.0.2

### DIFF
--- a/config/projects/supermarket.rb
+++ b/config/projects/supermarket.rb
@@ -35,6 +35,10 @@ override :git, version: "2.2.1"
 override :'chef-gem', version: '12.3.0'
 override :redis, version: '2.8.21'
 
+# pin berks to keep net-ssh at 2.9.2 as expected by Supermarket
+# chef, net-ssh, berks and rspec have gotten tangled
+override :berkshelf, version: 'a05e39202aebbb239e887a479c984b23167b5925'
+
 # Creates required build directories
 dependency "preparation"
 


### PR DESCRIPTION
Supermarket rails app requires the chef gem for version number logic. That
chef gem is Gemfile.lock'd to 12.0 which requires a 2.x version of net-ssh.
Riding berkshelf master in this software project meant the package build
pulled in a newer net-ssh in addition to the 2.9.2 that the rails app
needed. And then things got upset. Can't upgrade the chef gem immediately
because newer chef requires newer rspec which breaks our tests.

Good times.