### PR TITLE
Ignore vm.overcommit for redis on lxc

### DIFF
--- a/cookbooks/omnibus-supermarket/recipes/redis.rb
+++ b/cookbooks/omnibus-supermarket/recipes/redis.rb
@@ -45,6 +45,8 @@ end
 # Redis gives you a warning if you don't do this
 sysctl_param 'vm.overcommit_memory' do
   value 1
+  # ignore if on lxc.
+  not_if "grep -q lxc /proc/self/cgroup"
 end
 
 if node['supermarket']['redis']['enable']


### PR DESCRIPTION
Attempting to set this in an lxc container results in this

```
# sysctl -w "vm.overcommit_memory=1"
error: permission denied on key 'vm.overcommit_memory'
```

Even though

```
# id && mount | grep proc
uid=0(root) gid=0(root) groups=0(root)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
```
