### PR TITLE
Add logic to set header appropriate for SSL/non-SSL

### DIFF
--- a/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -14,6 +14,7 @@ provisioner:
 platforms:
   - name: ubuntu-10.04
   - name: ubuntu-12.04
+  - name: ubuntu-14.04
   - name: centos-5.11
   - name: centos-6.7
   - name: centos-7.1

--- a/cookbooks/omnibus-supermarket/spec/recipes/rails_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/rails_spec.rb
@@ -12,6 +12,26 @@ describe 'omnibus-supermarket::rails' do
       expect(chef_run).to create_template(rails_site_config)
     end
 
+    describe 'with ssl' do
+      it 'listens on default non_ssl_port' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).to include('listen 80')
+        }
+      end
+
+      it 'listens on default ssl_port' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).to include('listen 443')
+        }
+      end
+
+      it 'sets X-Forwarded-Proto header to "https"' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).to include('X-Forwarded-Proto https')
+        }
+      end
+    end
+
     describe 'with no ssl' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
@@ -21,9 +41,21 @@ describe 'omnibus-supermarket::rails' do
         end.converge(described_recipe)
       end
 
-      it 'does not include an SSL service' do
+      it 'listens on default non_ssl_port' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).to include('listen 80')
+        }
+      end
+
+      it 'does not listen on ssl_port' do
         expect(chef_run).to render_file(rails_site_config).with_content { |content|
           expect(content).not_to include('listen 443')
+        }
+      end
+
+      it 'sets X-Forwarded-Proto header to "http"' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).to include('X-Forwarded-Proto http')
         }
       end
 

--- a/cookbooks/omnibus-supermarket/spec/recipes/rails_spec.rb
+++ b/cookbooks/omnibus-supermarket/spec/recipes/rails_spec.rb
@@ -1,0 +1,37 @@
+describe 'omnibus-supermarket::rails' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.automatic['memory']['total'] = '16000MB'
+    end.converge(described_recipe)
+  end
+
+  describe 'rails app nginx site' do
+    let(:rails_site_config) { '/var/opt/supermarket/nginx/etc/sites-enabled/rails' }
+
+    it 'renders the site template' do
+      expect(chef_run).to create_template(rails_site_config)
+    end
+
+    describe 'with no ssl' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new do |node|
+          node.automatic['memory']['total'] = '16000MB'
+          node.automatic['supermarket']['ssl']['enabled'] = false
+          node.automatic['supermarket']['nginx']['force_ssl'] = false
+        end.converge(described_recipe)
+      end
+
+      it 'does not include an SSL service' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).not_to include('listen 443')
+        }
+      end
+
+      it 'does not set X-Forwarded-Proto header to "https"' do
+        expect(chef_run).to render_file(rails_site_config).with_content { |content|
+          expect(content).not_to include('X-Forwarded-Proto https')
+        }
+      end
+    end
+  end
+end

--- a/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
+++ b/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
@@ -120,7 +120,7 @@ server {
     proxy_set_header HOST $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;
-    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Proto <%= node['supermarket']['ssl']['enabled'] ? 'https' : 'http' %>;
     proxy_pass http://rails;
     proxy_redirect off;
 


### PR DESCRIPTION
Fixes chef/supermarket#1076

Adds a new spec for the rails recipe and some tests for this template.

This was the smallest change to fix the issue reported. The nginx template could use some renovation in the future.